### PR TITLE
ci: modify release.yaml to work with npm Trusted Publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,8 @@
 name: Release
 
 permissions:
+  # Needed for npm Trusted Publishing
+  id-token: write
   # Needed for semantic-release
   contents: write
   pull-requests: write
@@ -22,6 +24,6 @@ jobs:
   release:
     uses: semantic-release-action/typescript/.github/workflows/release.yml@1d40c29e2d500f3bcceeb13f95d26a3a1b571f51 # v3.0.20
     secrets:
-      npm-token: ${{ secrets.NPM_TOKEN }}
+      npm-token: "n/a"
     with:
       disable-semantic-release-git: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,6 @@ jobs:
   release:
     uses: semantic-release-action/typescript/.github/workflows/release.yml@1d40c29e2d500f3bcceeb13f95d26a3a1b571f51 # v3.0.20
     secrets:
-      npm-token: "n/a"
+      npm-token: "FAKE_NPM_TOKEN_FOR_SEMANTIC_RELEASE"
     with:
       disable-semantic-release-git: true


### PR DESCRIPTION
**Summary:**
This PR updates the GitHub Actions release workflow to use npm Trusted Publishing (OIDC) instead of long-lived `NPM_TOKEN` secrets.

**Changes:**
- Added `permissions: id-token: write` for OIDC-based publishing
- I added a dummy value `"FAKE_NPM_TOKEN_FOR_SEMANTIC_RELEASE"` in all repos to ensure that semantic-release passes

**Why:**
- We want to eliminate long-lived npm tokens, and use GitHub’s OIDC-based authentication for npm publishing instead
- Our semantic-release workflow (`semantic-release-action/typescript/blob/master/.github/workflows/release.yml`) defines `npm-token` as a required secret. So if it’s missing, the release can sometimes fail early or behave inconsistently. Some repos throw a hard error (`“Secret npm-token is required”`), while others partially run and then stop. By setting the dummy token, we eliminate those inconsistencies, guarantee that all release workflows start cleanly across repos, and ensure that future developers don't get confused as to why there is no `npm-token`
It doesn’t actually authenticate to npm, so it’s a harmless placeholder that prevents future CI failures

**Expected outcome:**
- Future releases will publish securely through GitHub’s OIDC workflow
- `npm-token` secrets are no longer required
- npm packages will show a "GitHub Actions" verification at the top of the npm package indicating that the Trusted Publishing has worked

Ticket: DX-2084

