### PR TITLE
Migrate to OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,8 +22,6 @@ on:
 
 jobs:
   release:
-    uses: semantic-release-action/typescript/.github/workflows/release.yml@1d40c29e2d500f3bcceeb13f95d26a3a1b571f51 # v3.0.20
-    secrets:
-      npm-token: "FAKE_NPM_TOKEN_FOR_SEMANTIC_RELEASE"
+    uses: semantic-release-action/typescript/.github/workflows/release.yml@70c4b6f612fd516692472d20eac1c590ac08cd20 # v3.1.0
     with:
       disable-semantic-release-git: true


### PR DESCRIPTION
**What problem are we solving?**
With OIDC Trusted Publishing, GHA authenticates directly with npm using short-lived identity tokens instead. 
- Eliminates the need to store long-lived npm tokens, improving security.
- Reduces secret management complexity across BitGo repositories, making maintenance simple.
- Improved scalability now that our release pipelines are self-contained within GitHub Actions.
- Necessary for npm compliance with their removal of classic npm-token's.

**Why solve it this way?**
This PR migrates our semantic-release workflow to use OIDC Trusted Publishing for npm releases. Previously, our release pipeline required an `npm-token` secret to authenticate with npm during publishing. This approach has since been discouraged by npm themselves. 
```
npm notice SECURITY NOTICE: 
   Breaking changes starting October 13, 2025. 
   New tokens will be limited to a maximum lifetime of 90 days, and TOTP setup will be disabled. 
   Classic tokens will be revoked in November. 
   Update your CI/CD workflows to avoid disruption. Learn more: https://gh.io/npm-token-changes
```

**Fixes:**
- Our semantic-release-action/typescript reusable workflow no longer enforces `npm-token` as a required secret, allowing us to remove that input so GHA knows to publish via OIDC Trusted Publishing.
- Add `id-token: write` permissions to the workflow to allow for GHA to request an OIDC token at runtime.
- Pinned the workflow the the updated version of `semantic-release-action/typescript/release.yml@v3.1.0`

**Testing:**
From our test/check logs, we can confirm that OIDC is being used instead of an npm token to establish a connection to npm.
```
[semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/npm"
[semantic-release] [@semantic-release/npm] › ℹ  Verifying OIDC context for publishing from GitHub Actions
[semantic-release] [@semantic-release/npm] › ℹ  OIDC token exchange with the npm registry succeeded
[semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/npm"
```

As confirmation of a successful release, see the beta pre-release tag that was created in the repo and in npmjs: https://www.npmjs.com/package/@bitgo-forks/io-ts/v/2.1.5-beta.1
https://github.com/BitGo/io-ts/actions/runs/19077165991
<img width="400" height="250" alt="image" src="https://github.com/user-attachments/assets/db4b8baf-ff99-416d-884a-6f6c7b6962b8" />



*Note: this PR should not trigger a new official release to `@bitgo-forks/io-ts` *