### PR TITLE
fix: add OIDC Trusted Publishing w/ Github Environments

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   release:
-    uses: semantic-release-action/typescript/.github/workflows/release.yml@70c4b6f612fd516692472d20eac1c590ac08cd20 # v3.1.0
+    uses: semantic-release-action/typescript/.github/workflows/release.yml@fd8c4abce3b0710e4e0d0ecf17fdaf2e770d4c82 # v3.2.0-beta.1
     with:
       disable-semantic-release-git: true
+      environment: publish


### PR DESCRIPTION
**What problem are we solving?**
Trigger release to npmjs using OIDC Trusted Publishing w/ Github Environments. Using Github Environments will enforce security through protected branch deployments and designated reviewer requirements.

**Why solve it this way?**
/io-ts uses the `semantic-release-action/typescript/.../release.yml` reusable workflow to run semantic-release. We triggered a beta-release v3.2.0-beta.1 that accepts `environment` as an input. That way, we can pass `environment: publish` input inside of `/io-ts/.../release.yaml`.

Ticket: DX-2084