### PR TITLE
ci: semantic-release-action/typescript v3.2.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   release:
-    uses: semantic-release-action/typescript/.github/workflows/release.yml@fd8c4abce3b0710e4e0d0ecf17fdaf2e770d4c82 # v3.2.0-beta.1
+    uses: semantic-release-action/typescript/.github/workflows/release.yml@07e8186507f8bb98bee59f67ce3e621c9098bc66 #v3.2.0
     with:
       disable-semantic-release-git: true
       environment: publish


### PR DESCRIPTION
**What problem are we solving?**
Now that we have released an official version of `semantic-release-action/typescript@v3.2.0`, we can move away from using the beta release.

**Why solve it this way?**
We just simply use the commit SHA attached to the new v3.2.0 release and replace the beta SHA.

Ticket: DX-2325
